### PR TITLE
readSubRecord Performance Improvement

### DIFF
--- a/omwllf.py
+++ b/omwllf.py
@@ -104,7 +104,8 @@ def readSubRecord(ba):
     sr['length'] = int.from_bytes(ba[4:8], 'little')
     endbyte = 8 + sr['length']
     sr['data'] = ba[8:endbyte]
-    return (sr, ba[endbyte:])
+    del ba[:endbyte]
+    return sr
 
 def readRecords(filename):
     fh = open(filename, 'rb')
@@ -121,12 +122,11 @@ def readRecords(filename):
         # stash the filename here (a bit hacky, but useful)
         record['fullpath'] = filename
 
-        remains = fh.read(header['length'])
+        remains = bytearray(fh.read(header['length']))
 
         while len(remains) > 0:
-            (subrecord, restofbytes) = readSubRecord(remains)
+            subrecord = readSubRecord(remains)
             record['subrecords'].append(subrecord)
-            remains = restofbytes
 
         yield record
 


### PR DESCRIPTION
Made readSubRecord consume part of a bytearray rather than copying the bytes every time via a slice.
This improves performance substantially (~3-4 times faster).

Unfortunately the performance of readSubRecord is still poor, likely due to creating a dictionary and copying strings into it every call.